### PR TITLE
Fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 npm-debug.log
-

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "node generate-expectations.js",
+    "generate": "node generate-expectations.js",
+    "build": "",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-parser-expectations",
-  "version": "2018.0.0",
+  "version": "2018.0.1",
   "description": "Shift ASTs for test262-parser-tests",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-parser-expectations",


### PR DESCRIPTION
Shape Jenkins runs build on every CI. The build will fail as there is a dependency on shift-parser. Hence adding a nop build script.