### PR TITLE
Fix build2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "index.js",
   "scripts": {
     "generate": "node generate-expectations.js",
-    "build": "",
+    "build": "echo \"This is temporary change to run CI\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-parser-expectations",
-  "version": "2018.0.1",
+  "version": "2018.0.2",
   "description": "Shift ASTs for test262-parser-tests",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-parser-expectations",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "index.js",
   "scripts": {
     "generate": "node generate-expectations.js",
-    "build": "echo \"This is temporary change to run CI\"",
+    "build": "exit 0",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
This projects is using a Jenkins job which runs `build` script by default in the CI. The current project is based on `shift-parser-js` project to generate expectations, and we are in the midst of updating es2018 features in the `shift-parser-js`. This PR allows us to make a release with the es2018 updated expectations.